### PR TITLE
Resolve model convert and early stopping

### DIFF
--- a/orli/model.py
+++ b/orli/model.py
@@ -175,10 +175,10 @@ class SegmentationModel(L.LightningModule):
     def configure_callbacks(self):
         callbacks = []
         if self.hparams.quit == 'early':
-            callbacks.append(EarlyStopping(monitor='val_accuracy',
-                                           mode='max',
+            callbacks.append(EarlyStopping(monitor='val_metric',
+                                           mode='min',
                                            patience=self.hparams.lag,
-                                           stopping_threshold=1.0))
+                                           stopping_threshold=0.0))
 
         return callbacks
 
@@ -276,7 +276,7 @@ def _configure_optimizer_and_lr_scheduler(hparams, params, loss_tracking_mode='m
         ret['lr_scheduler'] = lr_sched
 
     if schedule == 'reduceonplateau':
-        lr_sched['monitor'] = 'val_accuracy'
+        lr_sched['monitor'] = 'val_metric'
         lr_sched['strict'] = False
         lr_sched['reduce_on_plateau'] = True
 

--- a/orli/util.py
+++ b/orli/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Model format conversion routines"""
 import json
+import pathlib
 import torch
 
 from safetensors.torch import save_file, _remove_duplicate_names
@@ -31,6 +32,8 @@ def checkpoint_to_kraken(checkpoint_path: Union[str, 'PathLike'],
     Converts a lightning checkpoint and optional HTRMoPo model card to the new
     safetensors-based kraken serialization format.
     """
+    # Add PosixPath to safe globals for loading checkpoints
+    torch.serialization.add_safe_globals([pathlib.PosixPath])
     state_dict = torch.load(checkpoint_path, map_location=torch.device('cpu'), weights_only=True)
     # we do not have configurable encoders/decoders
     config = {"decoder_vocab_size": 12,


### PR DESCRIPTION
First patch:
Add PosixPath to safe globals for loading checkpoints to resolve this error:
```
UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint[0m.
        (1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL pathlib.PosixPath was not an allowed global by default. Please use `torch.serialization.add_safe_globals([PosixPath])` to allowlist this global if you trust this class/function.
```

Second patch:

Fix early stopping issue
### Changes Made:

  1. Fixed EarlyStopping callback configuration (lines 178-181):
    * Changed `monitor='val_accuracy'` to `monitor='val_metric'`
    * Changed `mode='max'` to `mode='min'` (since `val_metric` is a loss metric, lower is better)
    * Changed `stopping_threshold=1.0` to `stopping_threshold=0.0` (more appropriate for a loss metric)
  2. Fixed `ReduceLROnPlateau` scheduler configuration (line 279):
    * Changed `lr_sched['monitor'] = 'val_accuracy'` to `lr_sched['monitor'] = 'val_metric'`

### Why This Fixes the Issue:

The error occurred because:

  * The model logs a metric called `'val_metric'` in its `on_validation_epoch_end()` method
  * But the EarlyStopping callback was configured to monitor `'val_accuracy'`, which doesn't exist
  * The available metrics are: `train_loss`, `train_loss_step`, `val_metric`, and `global_step`

### What val_metric Represents:

  * `val_metric` is the mean validation loss computed across validation batches
  * Since it's a loss metric, lower values indicate better performance (hence `mode='min'`)