### PR TITLE
Update output option for compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ num_workers: 12
 num_threads: 1
 train:
   training_data:
-    - train.arrow
+    - train.lst
   evaluation_data:
-    - val.arrow
+    - val.lst
   checkpoint_path: experiments/orli_finetuned
   image_size: [1920, 1440]
   optimizer: AdamW

--- a/orli/cli/compile.py
+++ b/orli/cli/compile.py
@@ -29,7 +29,9 @@ logger = logging.getLogger('orli')
 
 @click.command('compile')
 @click.pass_context
-@click.option('-o', '--output', type=click.Path(), default='dataset.arrow',
+@click.option('-o', '--output', 
+              type=click.Path(dir_okay=False, writable=True), 
+              default='dataset.arrow',
               help='Output dataset file')
 @click.option('-F', '--files', default=None, multiple=True,
               callback=_validate_manifests, type=click.File(mode='r', lazy=True),


### PR DESCRIPTION
If by misstake is passed a directory, the script runs and crashes at the end.
```
│ /home/incognito/AI/orli/orli/cli/compile.py:75 in compile                                        │
│                                                                                                  │
│   72 │   │   │   │   progress.start_task(extract_task)                                           │
│   73 │   │   │   progress.update(extract_task, total=total, advance=advance)                     │
│   74 │   │                                                                                       │
│ ❱ 75 │   │   stats = dataset.compile(ground_truth,                                               │
│   76 │   │   │   │   │   │   │   │   params['output'],                                           │
│   77 │   │   │   │   │   │   │   │   resize=tuple(params['resize']) if params['resize'] else     │
│   78 │   │   │   │   │   │   │   │   allow_textless=params['allow_textless'],                    │
│                                                                                                  │
│ /home/incognito/AI/orli/orli/dataset.py:179 in compile                                           │
│                                                                                                  │
│   176 │   │   │   schema = schema.with_metadata(metadata)                                        │
│   177 │   │   │   ds_table = pa.ipc.open_file(source).read_all()                                 │
│   178 │   │   │   new_table = ds_table.replace_schema_metadata(metadata)                         │
│ ❱ 179 │   │   │   with pa.OSFile(output_file, 'wb') as sink:                                     │
│   180 │   │   │   │   with pa.ipc.new_file(sink, schema=schema) as writer:                       │
│   181 │   │   │   │   │   for batch in new_table.to_batches():                                   │
│   182 │   │   │   │   │   │   writer.write(batch)                                                │
│                                                                                                  │
│ in pyarrow.lib.OSFile.__cinit__:1231                                                             │
│                                                                                                  │
│ in pyarrow.lib._check_is_file:1149                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
OSError: Expected file path, but sam_44_data is a directory
```